### PR TITLE
Add `@namespace` (mandatory for Stylus)

### DIFF
--- a/styles/bilibili.user.css
+++ b/styles/bilibili.user.css
@@ -3,6 +3,7 @@
 @version      1.1.0
 @description  Hide Bilibili annoyances
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/bilibili.user.css
+++ b/styles/bilibili.user.css
@@ -3,7 +3,7 @@
 @version      1.1.0
 @description  Hide Bilibili annoyances
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/github.user.css
+++ b/styles/github.user.css
@@ -3,6 +3,7 @@
 @version      1.12.2
 @description  Style optimizations for GitHub
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 @preprocessor stylus
 

--- a/styles/github.user.css
+++ b/styles/github.user.css
@@ -3,7 +3,7 @@
 @version      1.12.2
 @description  Style optimizations for GitHub
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 @preprocessor stylus
 

--- a/styles/google-tasks.user.css
+++ b/styles/google-tasks.user.css
@@ -3,7 +3,7 @@
 @version      1.0.0
 @description  Google Tasks on desktop
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 @-moz-document regexp("https://tasks.google.com.*\\?fullWidth=1") {

--- a/styles/google-tasks.user.css
+++ b/styles/google-tasks.user.css
@@ -3,6 +3,7 @@
 @version      1.0.0
 @description  Google Tasks on desktop
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 @-moz-document regexp("https://tasks.google.com.*\\?fullWidth=1") {

--- a/styles/inoreader.user.css
+++ b/styles/inoreader.user.css
@@ -4,7 +4,7 @@
 @description  Tweaks for Inoreader light theme
 @license      CC0
 @author       阿文 & kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/inoreader.user.css
+++ b/styles/inoreader.user.css
@@ -4,6 +4,7 @@
 @description  Tweaks for Inoreader light theme
 @license      CC0
 @author       阿文 & kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/moegirl.user.css
+++ b/styles/moegirl.user.css
@@ -4,7 +4,7 @@
 @description  Moegirlpedia improved
 @license      CC-BY-NC-SA-4.0
 @author       LamentationsOfInnocence, Nibiruuu & kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/moegirl.user.css
+++ b/styles/moegirl.user.css
@@ -4,6 +4,7 @@
 @description  Moegirlpedia improved
 @license      CC-BY-NC-SA-4.0
 @author       LamentationsOfInnocence, Nibiruuu & kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/netlify.user.css
+++ b/styles/netlify.user.css
@@ -3,6 +3,7 @@
 @version      1.0.0
 @description  Hide Netlify annoyances
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/netlify.user.css
+++ b/styles/netlify.user.css
@@ -3,7 +3,7 @@
 @version      1.0.0
 @description  Hide Netlify annoyances
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/onedrive-business.user.css
+++ b/styles/onedrive-business.user.css
@@ -3,7 +3,7 @@
 @version      1.0.2
 @description  Hide OneDrive Business annoyances
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/onedrive-business.user.css
+++ b/styles/onedrive-business.user.css
@@ -3,6 +3,7 @@
 @version      1.0.2
 @description  Hide OneDrive Business annoyances
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/stackblitz.user.css
+++ b/styles/stackblitz.user.css
@@ -3,7 +3,7 @@
 @version      1.0.0
 @description  Hide StackBlitz annoyances
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/stackblitz.user.css
+++ b/styles/stackblitz.user.css
@@ -3,6 +3,7 @@
 @version      1.0.0
 @description  Hide StackBlitz annoyances
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/tieba.user.css
+++ b/styles/tieba.user.css
@@ -3,6 +3,7 @@
 @version      1.0.0
 @description  Hide Baidu Tieba annoyances
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/tieba.user.css
+++ b/styles/tieba.user.css
@@ -3,7 +3,7 @@
 @version      1.0.0
 @description  Hide Baidu Tieba annoyances
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/typeface.user.css
+++ b/styles/typeface.user.css
@@ -3,6 +3,7 @@
 @version      1.1.3
 @description  Typeface optimizations for various sites
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/typeface.user.css
+++ b/styles/typeface.user.css
@@ -3,7 +3,7 @@
 @version      1.1.3
 @description  Typeface optimizations for various sites
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/vercel.user.css
+++ b/styles/vercel.user.css
@@ -3,6 +3,7 @@
 @version      1.0.3
 @description  Hide Vercel annoyances
 @author       kidonng
+@namespace    kidonng
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/vercel.user.css
+++ b/styles/vercel.user.css
@@ -3,7 +3,7 @@
 @version      1.0.3
 @description  Hide Vercel annoyances
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 

--- a/styles/wikipedia.user.css
+++ b/styles/wikipedia.user.css
@@ -3,7 +3,8 @@
 @version      1.0.0
 @description  Wikipedia Material + Wikipedia New Light
 @author       kidonng
-@namespace    https://github.com/kidonng/cherry
+@namespace    kidonng
+@homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 
 @-moz-document domain("wikipedia.org"), domain("wikimedia.org") {

--- a/styles/wikipedia.user.css
+++ b/styles/wikipedia.user.css
@@ -3,7 +3,7 @@
 @version      1.0.0
 @description  Wikipedia Material + Wikipedia New Light
 @author       kidonng
-@namespace    kidonng
+@namespace    https://github.com/kidonng/cherry
 @homepageURL  https://github.com/kidonng/cherry
 ==/UserStyle== */
 


### PR DESCRIPTION
Greetings @kidonng 

With this PR I add  `@namespace` to all styles, which is mandatory when installing via Stylus (v1.5.15 in Chrome 88), 
otherwise it fails to parse it,
e.g. https://github.com/kidonng/cherry/blob/master/styles/github.user.css?raw=true currently results in:
![2021-02-21_123839](https://user-images.githubusercontent.com/723651/108622473-c616a080-7441-11eb-80c2-d16252d6fc53.jpg)

Thanks for your work!

